### PR TITLE
Obscure sensible values on .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME="Verify V2 Quickstart"
 APP_ENV=local
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_URL=http://localhost
 
 # Twilio API credentials

--- a/config/app.php
+++ b/config/app.php
@@ -245,7 +245,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Debug blacklist
+    | Debug hide
     |--------------------------------------------------------------------------
     |
     | Hiding environment variables on debug pages. For more information, visit
@@ -253,7 +253,7 @@ return [
     |
     */
 
-    'debug_blacklist' => [
+    'debug_hide' => [
         '_ENV' => [
             'APP_KEY',
             'DB_PASSWORD',

--- a/config/app.php
+++ b/config/app.php
@@ -243,4 +243,29 @@ return [
         'verification_sid' => env('TWILIO_VERIFICATION_SID'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Debug blacklist
+    |--------------------------------------------------------------------------
+    |
+    | Hiding environment variables on debug pages. For more information, visit
+    | https://laravel.com/docs/7.x/configuration#hiding-environment-variables-from-debug
+    |
+    */
+
+    'debug_blacklist' => [
+        '_ENV' => [
+            'APP_KEY',
+            'DB_PASSWORD',
+            'TWILIO_ACCOUNT_SID',
+            'TWILIO_AUTH_TOKEN',
+            'TWILIO_VERIFICATION_SID'
+        ],
+
+        '_SERVER' => [
+            'APP_KEY',
+            'DB_PASSWORD',
+        ],
+    ],
+
 ];

--- a/readme.md
+++ b/readme.md
@@ -47,12 +47,6 @@ After the above requirements have been met:
     cd verify-v2-quickstart-php
     ```
 
-1. Install PHP dependencies
-
-    ```bash
-    make install
-    ```
-
 1. Set your environment variables
 
     ```bash
@@ -60,6 +54,12 @@ After the above requirements have been met:
     ```
 
     See [Twilio Account Settings](#twilio-account-settings) to locate the necessary environment variables.
+
+1. Install PHP dependencies
+
+    ```bash
+    make install
+    ```
 
 1. Run the application
 


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- Change `APP_DEBUG` to `false`.
- Add `debug_blacklist` to avoid exposing sensible variables even when debug is `true`.
- Update README. Having a `.env` file is necessary for the `make install` step to succeed so now is first on the list.